### PR TITLE
[#97] 버그 수정

### DIFF
--- a/babasak/backend/db.py
+++ b/babasak/backend/db.py
@@ -650,6 +650,68 @@ def get_recipes_excluding_ingredient(keyword, exclude, limit=3):
 
 # 4. 대체재 추천
 
+_INGREDIENT_FAMILY_KEYWORDS = {
+    "pork": (
+        "돼지", "돼지고기", "돈육", "제육", "삼겹", "목살", "앞다리", "뒷다리",
+        "오겹", "항정", "갈매기살", "돼지갈비", "등갈비",
+    ),
+    "beef": (
+        "소고기", "쇠고기", "우육", "한우", "차돌", "양지", "사태", "등심",
+        "안심", "업진", "토시살", "부채살", "소갈비",
+    ),
+    "chicken": ("닭", "닭고기", "치킨", "닭다리", "닭가슴", "닭날개"),
+    "seafood": (
+        "참치", "고등어", "꽁치", "연어", "명태", "대구", "동태", "갈치",
+        "오징어", "낙지", "문어", "새우", "게", "조개", "홍합", "전복",
+        "해산물", "수산물",
+    ),
+    "processed_meat": ("스팸", "햄", "소시지", "소세지", "베이컨", "런천미트"),
+    "tofu": ("두부", "순두부", "연두부", "유부", "콩고기"),
+    "egg": ("계란", "달걀", "메추리알"),
+}
+
+_MENU_CORE_FAMILY_KEYWORDS = {
+    "pork": ("제육", "돼지", "돈육", "돼지불고기", "돈까스", "돈가스", "삼겹", "돼지갈비"),
+    "beef": ("소고기", "쇠고기", "한우", "불고기", "갈비탕", "소갈비", "육회", "차돌", "설렁탕"),
+    "chicken": ("닭", "치킨", "닭갈비", "삼계탕", "찜닭", "닭볶음탕"),
+    "seafood": ("참치", "고등어", "꽁치", "연어", "오징어", "낙지", "새우", "해물", "해산물", "조개"),
+    "tofu": ("두부", "순두부", "유부"),
+    "egg": ("계란", "달걀", "메추리알"),
+}
+
+
+def ingredient_family(name: str) -> str | None:
+    text = str(name or "").lower()
+    for family, keywords in _INGREDIENT_FAMILY_KEYWORDS.items():
+        if any(keyword.lower() in text for keyword in keywords):
+            return family
+    return None
+
+
+def menu_core_family(menu: str) -> str | None:
+    text = str(menu or "").lower()
+    for family, keywords in _MENU_CORE_FAMILY_KEYWORDS.items():
+        if any(keyword.lower() in text for keyword in keywords):
+            return family
+    return None
+
+
+def is_menu_core_ingredient(menu: str, ingredient: str) -> bool:
+    core_family = menu_core_family(menu)
+    return bool(core_family and ingredient_family(ingredient) == core_family)
+
+
+def is_allowed_substitute_for_menu(menu: str, target: str, candidate: str) -> bool:
+    """Keep core menu identity stable when suggesting substitutes."""
+    target_family = ingredient_family(target)
+    candidate_family = ingredient_family(candidate)
+    core_family = menu_core_family(menu)
+
+    if core_family and target_family == core_family:
+        return candidate_family == target_family
+    return True
+
+
 def suggest_substitute_ingredient(menu, missing_ingredient, limit=5):
     """주어진 메뉴에서 특정 재료를 대체할 만한 재료를 그래프 관계로 추천.
 
@@ -727,6 +789,8 @@ def suggest_substitute_ingredient(menu, missing_ingredient, limit=5):
     # 같은 재료 계열(같은 동물/소분류)이 위로 오게. 스팸·참치처럼 계열 신호 0인 건 뒤로.
     def _family_score(name, lv2):
         s = 0
+        if ingredient_family(name) and ingredient_family(name) == ingredient_family(missing):
+            s += 4
         if missing in name or name in missing:        # 돼지고기 ↔ 돼지고기목살
             s += 4
         if len(missing) >= 2 and len(name) >= 2 and missing[:2] == name[:2]:  # 돼지.. 공유
@@ -737,6 +801,8 @@ def suggest_substitute_ingredient(menu, missing_ingredient, limit=5):
 
     ranked = []
     for row in pool:
+        if not is_allowed_substitute_for_menu(menu, missing, row.get("name")):
+            continue
         fs = _family_score(row["name"], row.get("lv2"))
         ranked.append((fs, row.get("menu_count", 0), row.get("recipe_count", 0), row))
     # 계열성 > 메뉴 등장수 > 전체 빈도 순
@@ -783,7 +849,7 @@ def suggest_menu_protein_alternatives(menu, target, limit=8):
     핵심 아이디어: '어울리냐'를 하드코딩 규칙이 아니라 데이터로 판정.
       - 김치찌개 → 돼지고기·참치·스팸·꽁치 (참치김치찌개가 실제 있으니 참치 OK)
       - 미역국   → 소고기·홍합 (참치미역국 없으니 참치는 후보에 없음 = 괴식 차단)
-      - 제육볶음 → 돼지 부위·오징어 등
+      - 제육볶음 → 메뉴 핵심인 돼지고기 계열만 허용
 
     cost_calculator가 이 후보 중 target보다 '단가가 더 싼 것'을 골라 대체 제안.
     반환: [{"name", "lv1", "freq"}] (가격은 cost_calculator가 price_map에서 비교)
@@ -804,8 +870,11 @@ def suggest_menu_protein_alternatives(menu, target, limit=8):
     out = []
     for r in rows:
         lv1 = r.get("lv1") or ""
+        name = r.get("name") or ""
         if any(k in lv1 for k in _PROTEIN_LV1_KEYWORDS):
-            out.append({"name": r["name"], "lv1": lv1, "freq": r["freq"]})
+            if not is_allowed_substitute_for_menu(menu, target, name):
+                continue
+            out.append({"name": name, "lv1": lv1, "freq": r["freq"], "family": ingredient_family(name)})
         if len(out) >= limit:
             break
     return out

--- a/babasak/backend/nodes/cost_calculator.py
+++ b/babasak/backend/nodes/cost_calculator.py
@@ -7,6 +7,7 @@ from backend.db import (
     suggest_substitute_ingredient,
     get_menu_main_ingredient,
     suggest_menu_protein_alternatives,
+    is_allowed_substitute_for_menu,
 )
 
 
@@ -489,6 +490,68 @@ def _lookup_price(ingredient_name: str, price_map: dict) -> dict | None:
 BASE_COST_RATE = 0.30
 
 
+def _valid_rate(value) -> float | None:
+    try:
+        rate = float(value)
+    except (TypeError, ValueError):
+        return None
+    if rate > 1:
+        rate = rate / 100
+    if 0 < rate < 0.95:
+        return round(rate, 4)
+    return None
+
+
+def _pct_text(rate: float | None) -> str:
+    if rate is None:
+        return "-"
+    pct = round(rate * 100, 1)
+    return f"{pct:g}%"
+
+
+def _pricing_policy_from_state(state: dict) -> dict:
+    entities = state.get("entities") if isinstance(state, dict) else {}
+    entities = entities if isinstance(entities, dict) else {}
+
+    user_margin = _valid_rate(entities.get("target_margin_rate"))
+    user_cost_ratio = _valid_rate(entities.get("target_cost_ratio"))
+    pricing_source = entities.get("pricing_source")
+
+    if pricing_source == "user_margin" and user_margin is not None:
+        cost_ratio = round(1 - user_margin, 4)
+        margin_rate = user_margin
+        source = "user_margin"
+        label = f"사용자 마진율 {_pct_text(margin_rate)}"
+    elif pricing_source == "user_cost_ratio" and user_cost_ratio is not None:
+        cost_ratio = user_cost_ratio
+        margin_rate = round(1 - cost_ratio, 4)
+        source = "user_cost_ratio"
+        label = f"사용자 원가율 {_pct_text(cost_ratio)}"
+    elif user_margin is not None:
+        cost_ratio = round(1 - user_margin, 4)
+        margin_rate = user_margin
+        source = "user_margin"
+        label = f"사용자 마진율 {_pct_text(margin_rate)}"
+    elif user_cost_ratio is not None:
+        cost_ratio = user_cost_ratio
+        margin_rate = round(1 - cost_ratio, 4)
+        source = "user_cost_ratio"
+        label = f"사용자 원가율 {_pct_text(cost_ratio)}"
+    else:
+        cost_ratio = BASE_COST_RATE
+        margin_rate = round(1 - cost_ratio, 4)
+        source = "default_cost_ratio"
+        label = f"기본 원가율 {_pct_text(cost_ratio)}"
+
+    return {
+        "cost_ratio": cost_ratio,
+        "margin_rate": margin_rate,
+        "pricing_source": source,
+        "pricing_label": label,
+        "pricing_text": entities.get("pricing_text"),
+    }
+
+
 def ceil_to_100(value: float) -> int:
     """100원 단위 올림."""
     return int(math.ceil(value / 100) * 100)
@@ -521,7 +584,7 @@ def _extract_industry(state: dict) -> str:
     return ""
 
 
-# (업종별/사용자 원가율 해석 로직 제거 — 카드/판매가는 기준 원가율 BASE_COST_RATE(0.30) 고정 사용)
+# 사용자 입력이 없을 때만 BASE_COST_RATE를 쓰고, 입력된 마진율/원가율은 _pricing_policy_from_state에서 해석한다.
 
 
 def _parse_servings(servings) -> int:
@@ -662,8 +725,11 @@ def _format_recipe_section(calc: dict) -> str:
     if per is None:
         per = int(total / sv) if total else 0
     cr = calc.get("cost_ratio") or BASE_COST_RATE
+    margin_rate = calc.get("margin_rate")
+    if margin_rate is None:
+        margin_rate = round(1 - cr, 4)
+    pricing_label = calc.get("pricing_label") or f"기본 원가율 {_pct_text(cr)}"
     sell_price = reference_price(per, cr) or 0   # 1인분 기준, 원가율 역산 + 100원 올림
-    cr_pct = int(round(cr * 100))
     profit = (sell_price - per) if (sell_price and per) else 0
     lines.append("")
     lines.append(f"**총 원가 ({sv}인분 전체):** {total:,}원" + (
@@ -672,7 +738,8 @@ def _format_recipe_section(calc: dict) -> str:
     ))
     if total:
         lines.append(f"**1인분 예상 원가:** {per:,}원" + (f"  (전체 {total:,}원 ÷ {sv}인분)" if sv > 1 else ""))
-        lines.append(f"**참고 판매가 [원가율 {cr_pct}% 기준]:** {sell_price:,}원")
+        lines.append(f"**참고 판매가 [{pricing_label} 기준]:** {sell_price:,}원")
+        lines.append(f"**기준 원가율 / 예상 마진율:** {_pct_text(cr)} / {_pct_text(margin_rate)}")
         lines.append(f"**재료 기준 이익:** {profit:,}원")
     return "\n".join(lines)
 
@@ -786,6 +853,8 @@ def _build_substitute_line(calc: dict, price_map: dict) -> str:
             cname = c.get("name", "")
             if not cname or cname == tname:
                 continue
+            if not is_allowed_substitute_for_menu(menu, tname, cname):
+                continue
             # 후보도 '진짜 단백질명'이어야 한다. (Neo4j lv1 분류 노이즈로 김치국물·국물류가
             #  단백질로 새서 돼지고기 대체재로 뜨는 것 차단 — 물/국물류도 제외)
             if not _is_protein(cname) or _is_non_cost_ingredient(cname):
@@ -857,8 +926,10 @@ def cost_calculator_node(state: dict) -> dict:
     if not isinstance(recipes, list):
         recipes = [recipes] if recipes else []
 
-    # 기준 원가율(서비스 기본값, 사장님 목표값 아님). 참고 판매가/이익 계산 기준.
-    cost_ratio = BASE_COST_RATE
+    # 사용자 마진율/원가율 입력이 있으면 우선하고, 없으면 서비스 기본 원가율을 쓴다.
+    pricing_policy = _pricing_policy_from_state(state)
+    cost_ratio = pricing_policy["cost_ratio"]
+    margin_rate = pricing_policy["margin_rate"]
 
     calc_results = []
     for idx, recipe in enumerate(recipes, start=1):
@@ -866,7 +937,11 @@ def cost_calculator_node(state: dict) -> dict:
             continue
         recipe = {**recipe, "_rank": idx}
         c = _calc_recipe_cost(recipe, price_map)
-        c["cost_ratio"] = cost_ratio            # 마크다운·카드 판매가 계산 기준(기준 원가율)
+        c["cost_ratio"] = cost_ratio            # 마크다운·카드 판매가 계산 기준
+        c["margin_rate"] = margin_rate
+        c["pricing_source"] = pricing_policy["pricing_source"]
+        c["pricing_label"] = pricing_policy["pricing_label"]
+        c["pricing_text"] = pricing_policy.get("pricing_text")
         # 검증 로그: 레시피명/인분수/전체원가/1인분원가/카드표시원가/참고판매가/재료기준이익/제외재료
         _per = c.get("per_serving_cost")
         _ref = reference_price(_per, cost_ratio)
@@ -881,6 +956,8 @@ def cost_calculator_node(state: dict) -> dict:
             "reference_price": _ref,                      # 참고 판매가
             "material_profit": material_profit(_ref, _per),
             "cost_ratio": cost_ratio,
+            "margin_rate": margin_rate,
+            "pricing_source": pricing_policy["pricing_source"],
             "excluded_ingredients": _excluded,            # 원가 계산 제외 재료
         })
         calc_results.append(c)
@@ -889,6 +966,7 @@ def cost_calculator_node(state: dict) -> dict:
         "num_recipes": len(calc_results),
         "totals": [c["total_cost"] for c in calc_results],
         "unconfirmed_counts": [c["unconfirmed_count"] for c in calc_results],
+        "pricing": pricing_policy,
     })
 
     # 마크다운 조합 (+ 비싼 보조재료 대체 제안 라인 부착)

--- a/babasak/backend/nodes/missing_price_search.py
+++ b/babasak/backend/nodes/missing_price_search.py
@@ -3,7 +3,6 @@ import os
 import mlflow
 import mlflow.genai
 from mlflow.entities import SpanType
-from databricks_langchain import ChatDatabricks
 from langchain_core.messages import SystemMessage, HumanMessage
 
 from backend.search_backends import naver_search_structured
@@ -14,6 +13,8 @@ _llm = None
 def _get_llm():
     global _llm
     if _llm is None:
+        from databricks_langchain import ChatDatabricks
+
         _llm = ChatDatabricks(endpoint="databricks-gpt-5-4-mini", temperature=0.3)
     return _llm
 

--- a/babasak/backend/nodes/preprocessor.py
+++ b/babasak/backend/nodes/preprocessor.py
@@ -1,6 +1,7 @@
+import re
+
 import mlflow.genai
 from langchain_core.messages import HumanMessage, SystemMessage
-from databricks_langchain import ChatDatabricks
 
 from backend.debug_log import archive
 
@@ -43,6 +44,64 @@ _INTENT_KEYWORDS = {
 _INVALID_KEYWORDS = ['날씨', '주식', '비트코인', '뉴스', '영화', '여행', '수학', '코드', '번역', '노래', '게임', '택시']
 
 
+_RATE_VALUE_RE = r"(?P<value>\d+(?:\.\d+)?)\s*(?:%|퍼센트|프로)"
+_MARGIN_RATE_PATTERNS = [
+    re.compile(r"(?:마진율|마진|수익률|이익률|매출총이익률)\s*(?:은|는|을|를|로|:)?\s*" + _RATE_VALUE_RE, re.IGNORECASE),
+    re.compile(_RATE_VALUE_RE + r"\s*(?:마진율|마진|수익률|이익률|매출총이익률)", re.IGNORECASE),
+]
+_COST_RATIO_PATTERNS = [
+    re.compile(r"(?:원가율|식재료비율|재료비율|푸드코스트|food\s*cost|cost\s*ratio)\s*(?:은|는|을|를|로|:)?\s*" + _RATE_VALUE_RE, re.IGNORECASE),
+    re.compile(_RATE_VALUE_RE + r"\s*(?:원가율|식재료비율|재료비율|푸드코스트|food\s*cost|cost\s*ratio)", re.IGNORECASE),
+]
+
+
+def _rate_to_decimal(raw_value) -> float | None:
+    try:
+        value = float(raw_value)
+    except (TypeError, ValueError):
+        return None
+    if value > 1:
+        value = value / 100
+    if 0 < value < 0.95:
+        return round(value, 4)
+    return None
+
+
+def _detect_pricing_policy(query: str) -> dict:
+    """Extract user pricing intent from text."""
+    matches = []
+    for source, patterns in (("user_margin", _MARGIN_RATE_PATTERNS), ("user_cost_ratio", _COST_RATIO_PATTERNS)):
+        for pattern in patterns:
+            for match in pattern.finditer(query or ""):
+                rate = _rate_to_decimal(match.group("value"))
+                if rate is None:
+                    continue
+                matches.append((match.start(), source, rate, match.group(0).strip()))
+
+    if not matches:
+        return {
+            "target_margin_rate": None,
+            "target_cost_ratio": None,
+            "pricing_source": None,
+            "pricing_text": None,
+        }
+
+    _, source, rate, pricing_text = sorted(matches, key=lambda item: item[0])[-1]
+    if source == "user_margin":
+        margin_rate = rate
+        cost_ratio = round(1 - rate, 4)
+    else:
+        cost_ratio = rate
+        margin_rate = round(1 - rate, 4)
+
+    return {
+        "target_margin_rate": margin_rate,
+        "target_cost_ratio": cost_ratio,
+        "pricing_source": source,
+        "pricing_text": pricing_text,
+    }
+
+
 def _keyword_intent(query: str) -> str | None:
     """키워드 매칭으로 intent 1차 감지. 명확하면 LLM 스킵 가능."""
     priority = ['analytics', 'alternative', 'cost_analysis', 'price_inquiry', 'recipe_only', 'recommendation']
@@ -81,6 +140,8 @@ _llm = None
 def _get_llm():
     global _llm
     if _llm is None:
+        from databricks_langchain import ChatDatabricks
+
         _llm = ChatDatabricks(endpoint="databricks-gpt-5-4-mini", temperature=0, max_tokens=200)
     return _llm
 
@@ -400,6 +461,7 @@ def _build_result(*, is_valid, menu, ingredients, intent, query,
     # 신규: 유사 추천 / 1:1 대체재 의도 감지 (recipe_search.py 시나리오 8/9용)
     is_similar = _detect_is_similar(query)
     substitute_for = _detect_substitute_for(query, ingredients)
+    pricing_policy = _detect_pricing_policy(query)
 
     entities = {
         'menu': menu,
@@ -413,6 +475,10 @@ def _build_result(*, is_valid, menu, ingredients, intent, query,
         'is_similar': is_similar,
         'reference_menu': menu if is_similar else None,
         'substitute_for': substitute_for,
+        'target_margin_rate': pricing_policy["target_margin_rate"],
+        'target_cost_ratio': pricing_policy["target_cost_ratio"],
+        'pricing_source': pricing_policy["pricing_source"],
+        'pricing_text': pricing_policy["pricing_text"],
     }
 
     # rewritten_query: LLM 자연어 재해석 우선, 없으면 기계적 조합
@@ -456,7 +522,9 @@ def preprocessor_node(state: dict) -> dict:
                          'exclude': None, 'is_alternative': False,
                          'conditions': None, 'is_popular': False,
                          'is_similar': False, 'reference_menu': None,
-                         'substitute_for': None},
+                         'substitute_for': None,
+                         'target_margin_rate': None, 'target_cost_ratio': None,
+                         'pricing_source': None, 'pricing_text': None},
             'rewritten_query': '식당 운영/메뉴/원가 관련 질문이 아닙니다',
         }
 
@@ -472,7 +540,9 @@ def preprocessor_node(state: dict) -> dict:
                          'exclude': None, 'is_alternative': False,
                          'conditions': None, 'is_popular': False,
                          'is_similar': False, 'reference_menu': None,
-                         'substitute_for': None},
+                         'substitute_for': None,
+                         'target_margin_rate': None, 'target_cost_ratio': None,
+                         'pricing_source': None, 'pricing_text': None},
             'rewritten_query': '식당 운영/메뉴/원가 관련 질문이 아닙니다',
         }
 
@@ -531,6 +601,7 @@ def preprocessor_node(state: dict) -> dict:
         "phase": "1_llm",
         "menu": menu, "ingredients": ingredients, "intent": intent,
         "exclude": exclude, "rewritten": llm_result.get('rewritten'),
+        "pricing": _detect_pricing_policy(query),
         "interpretations": llm_result.get('interpretations', []),
     })
 

--- a/babasak/backend/nodes/recipe_search.py
+++ b/babasak/backend/nodes/recipe_search.py
@@ -13,7 +13,6 @@ from backend.db import (
     find_similar_recipes,           
     suggest_substitute_ingredient, 
 )
-from databricks_langchain import ChatDatabricks
 from langchain_core.messages import SystemMessage, HumanMessage
 
 # 폴백용 키워드 리스트
@@ -100,6 +99,8 @@ def _get_llm_keyword():
     """키워드 추출용 경량 LLM (lazy init)"""
     global _llm_keyword
     if _llm_keyword is None:
+        from databricks_langchain import ChatDatabricks
+
         _llm_keyword = ChatDatabricks(endpoint="databricks-gpt-5-4-mini", temperature=0, max_tokens=20)
     return _llm_keyword
 

--- a/babasak/backend/nodes/report_generator.py
+++ b/babasak/backend/nodes/report_generator.py
@@ -1,7 +1,6 @@
 import re
 import mlflow.genai
 
-from databricks_langchain import ChatDatabricks
 from langchain_core.messages import SystemMessage, HumanMessage, AIMessage
 
 from backend.debug_log import archive
@@ -70,6 +69,8 @@ _llm_report = None
 def _get_llm_report():
     global _llm_report
     if _llm_report is None:
+        from databricks_langchain import ChatDatabricks
+
         # streaming=True: astream_events에서 on_chat_model_stream 이벤트 발생에 필요
         _llm_report = ChatDatabricks(endpoint="databricks-gpt-5-4-mini", temperature=0.7, streaming=True)
     return _llm_report
@@ -338,6 +339,10 @@ def _build_card_data(recipe_info: dict, cost_info: dict) -> dict:
         if per is None:
             per = int(total / servings_num) if total else None
         cr = calc.get("cost_ratio") or BASE_COST_RATE       # 기준 원가율(서비스 기본값 0.30)
+        mr = calc.get("margin_rate")
+        if mr is None:
+            mr = round(1 - cr, 4)
+        pricing_label = calc.get("pricing_label") or f"기본 원가율 {round(cr * 100):g}%"
         ref = reference_price(per, cr)                      # 참고 판매가(100원 올림)
         # 원가 계산 제외 재료(물/국물·시세 미확인)
         excluded = [it.get("name") for it in (calc.get("items") or [])
@@ -354,6 +359,10 @@ def _build_card_data(recipe_info: dict, cost_info: dict) -> dict:
             "full_cost": total if total else None,           # 전체 N인분 원가(= 상세표 합계)
             "suggested_price": ref,                          # 참고 판매가(원가율 기준, 100원 올림)
             "cost_ratio_pct": int(round(cr * 100)),          # 기준 원가율 %(30)
+            "margin_pct": int(round(mr * 100)),              # 예상 마진율 %(원가율의 보수값)
+            "pricing_source": calc.get("pricing_source") or "default_cost_ratio",
+            "pricing_label": pricing_label,
+            "pricing_text": calc.get("pricing_text"),
             "material_profit": material_profit(ref, per),    # 재료 기준 이익
             "excluded_ingredients": excluded,                # 원가 계산 제외 재료
             "ingredients": ings_out,

--- a/babasak/backend/nodes/router.py
+++ b/babasak/backend/nodes/router.py
@@ -1,4 +1,3 @@
-from databricks_langchain import ChatDatabricks
 from langchain_core.messages import SystemMessage, HumanMessage
 
 from backend.debug_log import archive
@@ -18,6 +17,8 @@ _llm_router = None
 def _get_llm_router():
     global _llm_router
     if _llm_router is None:
+        from databricks_langchain import ChatDatabricks
+
         _llm_router = ChatDatabricks(endpoint="databricks-gpt-5-4-mini", temperature=0.1)
     return _llm_router
 
@@ -164,8 +165,15 @@ def router_node(state: dict) -> dict:
         HumanMessage(content=f"사용자 질문: {query}")
     ]
 
-    response = _get_llm_router().invoke(messages)
-    decision = response.content.strip().lower()
+    try:
+        response = _get_llm_router().invoke(messages)
+        decision = response.content.strip().lower()
+    except Exception as e:
+        archive("router.error", {
+            "reason": "llm_fallback_failed",
+            "error": str(e),
+        })
+        return {"next_action": "report_generator", "loop_count": loop_count}
 
     valid = ["recipe_search", "price_search", "missing_price_search", "cost_calculator", "report_generator"]
     matched = "report_generator"

--- a/babasak/requirements.txt
+++ b/babasak/requirements.txt
@@ -10,6 +10,7 @@ langgraph>=1.1.10
 langchain-core
 langchain
 databricks-langchain
+databricks-vectorsearch==0.73
 numpy
 mlflow[databricks]
 python-dotenv

--- a/babasak/views/chatbot.py
+++ b/babasak/views/chatbot.py
@@ -244,6 +244,7 @@ def _inject_card_css():
                 padding:13px 15px; margin:12px 0; font-size:.9rem; }
       .fc-chip { background:#f0fdf4; border:1px solid #86efac; border-radius:9px;
                  padding:4px 11px; font-weight:800; color:#15803d; display:inline-block; }
+      .fc-muted { color:#64748b; font-size:.82rem; }
       .fc-steps { margin:4px 0 0; padding-left:20px; }
       .fc-steps li { margin:5px 0; color:#334155; }
       .fc-nm { background:#faf5ff; border:1px solid #e9d5ff; border-radius:14px;
@@ -343,14 +344,15 @@ def _recipe_card_html(rc: dict, idx: int, single: bool, group: str = "rc") -> st
 
     summary = ""
     if total:
-        cr = rc.get("cost_ratio_pct") or 32      # 목표 원가율(업종/사용자), 없으면 32
+        cr = rc.get("cost_ratio_pct") or 30      # 백엔드 기준 원가율, 없으면 서비스 기본값
         mp = rc.get("margin_pct") or (100 - cr)  # 매출총이익률 = 100 - 원가율
+        pricing_label = _esc(rc.get("pricing_label") or f"원가율 {cr}%")
         srows = [f'<div class="fc-srow"><span class="k">예상 원가</span><span class="v">{_won(total)}</span></div>']
         if price:
-            srows.append(f'<div class="fc-srow"><span class="k">권장 판매가 (원가율 {cr}%)</span>'
+            srows.append(f'<div class="fc-srow"><span class="k">권장 판매가 ({pricing_label})</span>'
                          f'<span class="v">{_won(price)}</span></div>')
         srows.append(f'<div class="fc-srow"><span class="k">예상 마진율</span>'
-                     f'<span class="v fc-green">{mp}% ▲</span></div>')
+                     f'<span class="v fc-green">{mp}%</span></div>')
         summary = '<div class="fc-summary">' + "".join(srows) + '</div>'
 
     meta = " · ".join(str(x) for x in [rc.get("servings"), rc.get("difficulty"),
@@ -362,8 +364,10 @@ def _recipe_card_html(rc: dict, idx: int, single: bool, group: str = "rc") -> st
     sub = rc.get("substitute")
     if sub and sub.get("candidates"):
         cands = " · ".join(f'🍗 {_esc(c)}' for c in sub["candidates"])
+        saving = sub.get("saving_pct")
+        saving_txt = f'<br><span class="fc-muted">예상 절감률 {saving}%</span>' if saving is not None else ""
         body += (f'<div class="fc-sub">💡 <b>{_esc(sub.get("target","주재료"))} 비싸면 이렇게 바꿔보세요</b><br>'
-                 f'<span class="fc-chip">{cands}</span></div>')
+                 f'<span class="fc-chip">{cands}</span>{saving_txt}</div>')
 
     steps = rc.get("steps") or []
     if steps:


### PR DESCRIPTION
- Databricks Apps 환경에서 uvicorn 백엔드가 시작 중 죽는 버그 수정
  - 실제 LLM 호출 시점에만 ChatDatabricks lazy import 하도록 변경
  - 대상: preprocessor, router, recipe_search, missing_price_search, report_generator

- databricks-vectorsearch 버전 충돌 방지
  - requirements.txt에 databricks-vectorsearch==0.73 pin 추가
  - VectorSearchIndex import 오류로 FastAPI 서버가 뜨지 않던 문제 수정

- router LLM fallback 안정성 보강
  - LLM 라우팅 실패 시 요청 전체가 죽지 않고 report_generator로 이동하도록 방어 처리

- 사용자 입력 마진율/원가율 반영
  - “마진율 25%” 입력 시 원가율 75% 기준으로 판매가 계산
  - “원가율 35%” 입력 시 원가율 35% 기준으로 판매가 계산
  - 입력값이 없으면 기존 기본 원가율 30% 유지
  - 계산 결과와 Streamlit 카드에 pricing_label, margin_pct 전달

- 대체재료 추천 정책 개선
  - 제육볶음의 돼지고기처럼 메뉴 정체성을 이루는 핵심 재료는 같은 계열 후보만 허용
  - 참치/스팸/두부처럼 메뉴 자체가 바뀌는 자동 대체 추천 차단
  - 기존 test 커밋의 후보 가격 조회, B2B 노이즈 제거



